### PR TITLE
Fix serial port name escape on Windows

### DIFF
--- a/include/serial/impl/impl.h
+++ b/include/serial/impl/impl.h
@@ -55,6 +55,17 @@
 
 namespace serial {
 
+#if defined(_WIN32)
+inline std::string escape(const std::string &str) {
+  std::smatch match;
+  std::regex_search(str, match, std::regex(R"(^\\\\.\\)"));
+  if (match.empty()) {
+    return R"(\\.\)" + str;
+  }
+  return str;
+}
+#endif
+
 class Serial::SerialImpl {
  public:
   SerialImpl(std::string port, unsigned long baudrate, Timeout timeout, bytesize_t bytesize, parity_t parity,

--- a/src/impl/impl_win.cpp
+++ b/src/impl/impl_win.cpp
@@ -25,15 +25,6 @@
 
 using namespace serial;
 
-std::string escape(const std::string &str) {
-  std::smatch match;
-  std::regex_search(str, match, std::regex(R"(^\\\\.\\)"));
-  if (match.empty()) {
-    return R"(\\.\)" + str;
-  }
-  return str;
-}
-
 Serial::SerialImpl::SerialImpl(std::string port, unsigned long baudrate, Timeout timeout, bytesize_t bytesize,
                                parity_t parity, stopbits_t stopbits, flowcontrol_t flowcontrol)
     : port_(std::move(port)),

--- a/src/impl/impl_win.cpp
+++ b/src/impl/impl_win.cpp
@@ -25,12 +25,13 @@
 
 using namespace serial;
 
-inline std::wstring _prefix_port_if_needed(const std::wstring &input) {
-  static std::wstring windows_com_port_prefix = L"\\\\.\\";
-  if (input.compare(windows_com_port_prefix) != 0) {
-    return windows_com_port_prefix + input;
+std::string escape(const std::string &str) {
+  std::smatch match;
+  std::regex_search(str, match, std::regex(R"(^\\\\.\\)"));
+  if (match.empty()) {
+    return R"(\\.\)" + str;
   }
-  return input;
+  return str;
 }
 
 Serial::SerialImpl::SerialImpl(std::string port, unsigned long baudrate, Timeout timeout, bytesize_t bytesize,
@@ -61,10 +62,8 @@ void Serial::SerialImpl::open() {
     return;
   }
 
-  // See: https://github.com/wjwwood/serial/issues/84
-  std::wstring port_with_prefix = _prefix_port_if_needed(std::wstring(port_.begin(), port_.end()));
-  LPCWSTR lp_port = port_with_prefix.c_str();
-  fd_ = ::CreateFileW(lp_port, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  std::string escaped_port = escape(port_);
+  fd_ = ::CreateFileW(std::wstring(escaped_port.begin(), escaped_port.end()).c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (fd_ == INVALID_HANDLE_VALUE) {
     throw SerialIOException("failure during ::CreateFileW()", ::GetLastError());
   }

--- a/src/impl/list_ports/list_ports_win.cpp
+++ b/src/impl/list_ports/list_ports_win.cpp
@@ -30,13 +30,9 @@
 #include <usbioctl.h>
 #include <usbiodef.h>
 
-#include <serial/serial.h>
+#include <serial/impl/impl.h>
 
 using namespace serial;
-
-std::string escape(const std::string &str) {
-  return R"(\\.\)" + str;
-}
 
 template <typename T>
 std::shared_ptr<T> sharedPtr(size_t size = 0) {


### PR DESCRIPTION
This finally fix #21 (wjwwood/serial#179) together with the fixes in #25 and #26.